### PR TITLE
#7 로그인 컨트롤러 수정 및 인증 서비스 클래스 이동

### DIFF
--- a/src/main/java/com/donggi/sendzy/common/security/AuthService.java
+++ b/src/main/java/com/donggi/sendzy/common/security/AuthService.java
@@ -1,4 +1,4 @@
-package com.donggi.sendzy.member.application;
+package com.donggi.sendzy.common.security;
 
 import com.donggi.sendzy.member.dto.LoginRequest;
 import com.donggi.sendzy.member.exception.InvalidPasswordException;

--- a/src/main/java/com/donggi/sendzy/common/security/CustomUserDetails.java
+++ b/src/main/java/com/donggi/sendzy/common/security/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.donggi.sendzy.common.config;
+package com.donggi.sendzy.common.security;
 
 import com.donggi.sendzy.member.domain.Member;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/donggi/sendzy/common/security/SecurityConfig.java
+++ b/src/main/java/com/donggi/sendzy/common/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.donggi.sendzy.common.config;
+package com.donggi.sendzy.common.security;
 
 import com.donggi.sendzy.member.domain.MemberService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/donggi/sendzy/member/presentation/LoginRestController.java
+++ b/src/main/java/com/donggi/sendzy/member/presentation/LoginRestController.java
@@ -16,6 +16,12 @@ public class LoginRestController {
 
     private final AuthService authService;
 
+    /**
+     * 세션 생성을 위해 매개 변수로 HttpSession을 선언합니다.
+     * Spring은 HttpSession을 생성해서 주입해줍니다.
+     *
+     * HttpServletRequest을 매개변수로 받아와서, getSession() 메서드를 호출하여 명시적으로 세션을 생성하는 방법도 있습니다.
+     */
     @PostMapping
     public void login(
         @RequestBody final LoginRequest request,

--- a/src/main/java/com/donggi/sendzy/member/presentation/LoginRestController.java
+++ b/src/main/java/com/donggi/sendzy/member/presentation/LoginRestController.java
@@ -1,20 +1,14 @@
 package com.donggi.sendzy.member.presentation;
 
-import com.donggi.sendzy.member.application.AuthService;
-import com.donggi.sendzy.member.dto.LoginRequest;
 import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/login")
-@RequiredArgsConstructor
 public class LoginRestController {
-
-    private final AuthService authService;
 
     /**
      * 세션 생성을 위해 매개 변수로 HttpSession을 선언합니다.
@@ -23,10 +17,7 @@ public class LoginRestController {
      * HttpServletRequest을 매개변수로 받아와서, getSession() 메서드를 호출하여 명시적으로 세션을 생성하는 방법도 있습니다.
      */
     @PostMapping
-    public void login(
-        @RequestBody final LoginRequest request,
-        final HttpSession httpSession
-    ) {
-        authService.authenticate(request);
+    public ResponseEntity<Void> login(final HttpSession httpSession) {
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/com/donggi/sendzy/member/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/donggi/sendzy/member/integration/LoginIntegrationTest.java
@@ -59,7 +59,9 @@ public class LoginIntegrationTest {
                 .when()
                     .post(LOGIN_URL)
                 .then()
-                    .statusCode(HttpStatus.OK.value());
+                    .statusCode(HttpStatus.OK.value())
+                    .cookie("JSESSIONID")
+                ;
             }
         }
 


### PR DESCRIPTION
로그인 요청이 Spring Security의 `AuthenticationFilter`를 통해 동작하기 때문에 로그인 컨트롤러에서 인증 서비스를 호출하는 작업은 불필요하다고 판단하여 이를 수정하였습니다. 또한 다음과 같은 변경 사항이 있습니다.

- 로그인 메서드에 세션 생성에 관한 주석을 추가하였습니다.
- 인증 서비스는 member 컨텍스트의 응용 계층에서 common 의 security 패키지를 생성한 뒤 해당 패키지 하위로 이동하였습니다.