### PR TITLE
#26 송금 요청 수락/거절 기능

### DIFF
--- a/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
+++ b/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
@@ -2,13 +2,13 @@ package com.donggi.sendzy.account.application;
 
 import com.donggi.sendzy.account.domain.Account;
 import com.donggi.sendzy.account.domain.AccountRepository;
+import com.donggi.sendzy.account.domain.LockedAccounts;
 import com.donggi.sendzy.account.exception.AccountNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
@@ -20,17 +20,19 @@ public class AccountLockingService {
     /**
      * 두 개의 계좌를 계좌 ID 기준으로 오름차순 정렬하여 락을 획득합니다.
      * 데드락을 방지하기 위해 항상 일정한 순서로 락을 획득합니다.
-     * @param accountId1 첫 번째 계좌 ID
-     * @param accountId2 두 번째 계좌 ID
-     * @return ID 오름차순으로 정렬된 두 계좌 목록
+     * @param senderId 송금 회원 ID
+     * @param receiverId 수신 회원 ID
+     * @return 락을 획득한 계좌 목록
      */
     @Transactional
-    public List<Account> getAccountsWithLockOrdered(final long accountId1, final long accountId2) {
-        List<Long> sortedIds = getSortedIds(accountId1, accountId2);
-        return sortedIds.stream()
+    public LockedAccounts getAccountsWithLockOrdered(final long senderId, final long receiverId) {
+        final List<Long> sortedIds = getSortedIds(senderId, receiverId);
+        final List<Account> lockedAccounts = sortedIds.stream()
             .map(accountId -> accountRepository.findByMemberIdForUpdate(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId)))
-            .collect(Collectors.toList());
+            .toList();
+
+        return LockedAccounts.of(lockedAccounts, senderId, receiverId);
     }
 
     /**

--- a/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
+++ b/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
@@ -1,0 +1,41 @@
+package com.donggi.sendzy.account.application;
+
+import com.donggi.sendzy.account.domain.Account;
+import com.donggi.sendzy.account.domain.AccountRepository;
+import com.donggi.sendzy.account.exception.AccountNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Service
+public class AccountLockingService {
+
+    private final AccountRepository accountRepository;
+
+    /**
+     * 두 개의 계좌를 계좌 ID 기준으로 오름차순 정렬하여 락을 획득합니다.
+     * 데드락을 방지하기 위해 항상 일정한 순서로 락을 획득합니다.
+     * @param accountId1 첫 번째 계좌 ID
+     * @param accountId2 두 번째 계좌 ID
+     * @return ID 오름차순으로 정렬된 두 계좌 목록
+     */
+    @Transactional(readOnly = true)
+    public List<Account> getAccountsWithLockOrdered(final long accountId1, final long accountId2) {
+        List<Long> sortedIds = getSortedIds(accountId1, accountId2);
+        return sortedIds.stream()
+            .map(accountId -> accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new AccountNotFoundException(accountId)))
+            .collect(Collectors.toList());
+    }
+
+    private List<Long> getSortedIds(final long senderId, final long receiverId) {
+        return Stream.of(senderId, receiverId)
+            .sorted()
+            .toList();
+    }
+}

--- a/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
+++ b/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
@@ -28,9 +28,20 @@ public class AccountLockingService {
     public List<Account> getAccountsWithLockOrdered(final long accountId1, final long accountId2) {
         List<Long> sortedIds = getSortedIds(accountId1, accountId2);
         return sortedIds.stream()
-            .map(accountId -> accountRepository.findByIdForUpdate(accountId)
+            .map(accountId -> accountRepository.findByMemberIdForUpdate(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId)))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * 회원 ID로 계좌를 조회하고 해당 계좌의 락을 획득합니다.
+     * @param senderId 송신자 ID
+     * @return 조회된 계좌
+     */
+    @Transactional(readOnly = true)
+    public Account getByMemberIdForUpdate(final long senderId) {
+        return accountRepository.findByMemberIdForUpdate(senderId)
+            .orElseThrow(() -> new AccountNotFoundException(senderId));
     }
 
     private List<Long> getSortedIds(final long senderId, final long receiverId) {

--- a/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
+++ b/src/main/java/com/donggi/sendzy/account/application/AccountLockingService.java
@@ -24,7 +24,7 @@ public class AccountLockingService {
      * @param accountId2 두 번째 계좌 ID
      * @return ID 오름차순으로 정렬된 두 계좌 목록
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public List<Account> getAccountsWithLockOrdered(final long accountId1, final long accountId2) {
         List<Long> sortedIds = getSortedIds(accountId1, accountId2);
         return sortedIds.stream()
@@ -38,7 +38,7 @@ public class AccountLockingService {
      * @param senderId 송신자 ID
      * @return 조회된 계좌
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public Account getByMemberIdForUpdate(final long senderId) {
         return accountRepository.findByMemberIdForUpdate(senderId)
             .orElseThrow(() -> new AccountNotFoundException(senderId));

--- a/src/main/java/com/donggi/sendzy/account/domain/Account.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/Account.java
@@ -22,9 +22,14 @@ public class Account {
         this.pendingAmount = 0L;
     }
 
-    public void withdraw(final Long amount) {
+    public void reserveWithdraw(final Long amount) {
         validateWithdraw(amount);
         this.pendingAmount += amount;
+    }
+
+    public void commitWithdraw(final long amount) {
+        this.balance -= amount;
+        this.pendingAmount -= amount;
     }
 
     public void deposit(final Long amount) {

--- a/src/main/java/com/donggi/sendzy/account/domain/Account.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/Account.java
@@ -32,6 +32,10 @@ public class Account {
         this.pendingAmount -= amount;
     }
 
+    public void cancelWithdraw(final long amount) {
+        this.pendingAmount -= amount;
+    }
+
     public void deposit(final Long amount) {
         final var fieldName = "amount";
         Validator.notNull(amount, fieldName);

--- a/src/main/java/com/donggi/sendzy/account/domain/AccountRepository.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/AccountRepository.java
@@ -16,26 +16,18 @@ public interface AccountRepository {
      * @param memberId 회원 ID
      * @return 조회된 계좌
      */
-    Optional<Account> findByMemberId(final Long memberId);
+    Optional<Account> findByMemberId(final long memberId);
 
     /**
      * 회원 ID로 계좌를 조회하고, 조회된 계좌에 배타적 잠금(Exclusive Lock)을 겁니다.
      * @param memberId 회원 ID
      * @return 잠금이 설정된 계좌(Optional)
      */
-    Optional<Account> findByIdForUpdate(final Long memberId);
+    Optional<Account> findByMemberIdForUpdate(final long memberId);
 
     /**
-     * 계좌의 대기 중인 금액을 업데이트합니다.
-     * @param id 계좌 ID
-     * @param pendingAmount 대기 중인 금액
+     * 계좌를 업데이트합니다.
+     * @param account 업데이트할 계좌
      */
-    void updatePendingAmount(final Long id, final Long pendingAmount);
-
-    /**
-     * 계좌의 잔액을 업데이트합니다.
-     * @param id 계좌 ID
-     * @param balance 잔액
-     */
-    void updateBalance(final Long id, final Long balance);
+    void update(final Account account);
 }

--- a/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
@@ -20,18 +20,12 @@ public class AccountService {
     @Transactional
     public void withdraw(final Account account, final long amount) {
         account.reserveWithdraw(amount);
-        accountRepository.updatePendingAmount(account.getId(), account.getPendingAmount());
+        accountRepository.update(account);
     }
 
     @Transactional
     public void deposit(final Account account, final long amount) {
         account.deposit(amount);
-        accountRepository.updateBalance(account.getId(), account.getBalance());
-    }
-
-    @Transactional(readOnly = true)
-    public Account getByIdForUpdate(final long memberId) {
-        return accountRepository.findByIdForUpdate(memberId)
-            .orElseThrow(() -> new AccountNotFoundException(memberId));
+        accountRepository.update(account);
     }
 }

--- a/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
@@ -28,4 +28,17 @@ public class AccountService {
         account.deposit(amount);
         accountRepository.update(account);
     }
+
+    @Transactional
+    public void transfer(final Account sender, final Account receiver, final long amount) {
+        sender.commitWithdraw(amount);
+        receiver.deposit(amount);
+        accountRepository.update(sender);
+        accountRepository.update(receiver);
+    }
+
+    @Transactional
+    public void update(final Account account) {
+        accountRepository.update(account);
+    }
 }

--- a/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/AccountService.java
@@ -19,7 +19,7 @@ public class AccountService {
 
     @Transactional
     public void withdraw(final Account account, final long amount) {
-        account.withdraw(amount);
+        account.reserveWithdraw(amount);
         accountRepository.updatePendingAmount(account.getId(), account.getPendingAmount());
     }
 

--- a/src/main/java/com/donggi/sendzy/account/domain/LockedAccounts.java
+++ b/src/main/java/com/donggi/sendzy/account/domain/LockedAccounts.java
@@ -1,0 +1,23 @@
+package com.donggi.sendzy.account.domain;
+
+import java.util.List;
+
+/**
+ * 락이 걸린 송금자 계좌와 수신자 계좌를 묶어 표현하는 도메인 객체
+ *
+ * @param senderAccount 송금자 계좌
+ * @param receiverAccount 수신자 계좌
+ */
+public record LockedAccounts(
+    Account senderAccount,
+    Account receiverAccount
+) {
+    public static LockedAccounts of(final List<Account> lockedAccounts, final long senderId, final long receiverId) {
+        final var first = lockedAccounts.get(0);
+        final var second = lockedAccounts.get(1);
+
+        final var sender = first.getMemberId() == senderId ? first : second;
+        final var receiver = first.getMemberId() == receiverId ? first : second;
+        return new LockedAccounts(sender, receiver);
+    }
+}

--- a/src/main/java/com/donggi/sendzy/account/infrastructure/AccountMapper.java
+++ b/src/main/java/com/donggi/sendzy/account/infrastructure/AccountMapper.java
@@ -4,7 +4,6 @@ import com.donggi.sendzy.account.domain.Account;
 import com.donggi.sendzy.account.domain.AccountRepository;
 import com.donggi.sendzy.account.domain.TestAccountRepository;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -12,11 +11,11 @@ import java.util.Optional;
 public interface AccountMapper extends AccountRepository, TestAccountRepository {
     Long create(final Account account);
 
-    Optional<Account> findByMemberId(final Long memberId);
-
     void deleteAll();
 
-    void updatePendingAmount(@Param("id") final Long id, @Param("pendingAmount") final Long pendingAmount);
+    void update(final Account account);
 
-    void updateBalance(@Param("id") final Long id, @Param("balance") final Long balance);
+    Optional<Account> findByMemberId(final long memberId);
+
+    Optional<Account> findByMemberIdForUpdate(final long memberId);
 }

--- a/src/main/java/com/donggi/sendzy/common/exception/ClientErrorControllerAdvice.java
+++ b/src/main/java/com/donggi/sendzy/common/exception/ClientErrorControllerAdvice.java
@@ -3,7 +3,7 @@ package com.donggi.sendzy.common.exception;
 import com.donggi.sendzy.account.exception.InvalidWithdrawalException;
 import com.donggi.sendzy.member.exception.EmailDuplicatedException;
 import com.donggi.sendzy.member.exception.InvalidPasswordException;
-import com.donggi.sendzy.member.exception.MemberNotFoundException;
+import com.donggi.sendzy.remittance.exception.InvalidRemittanceRequestStatusException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.access.AccessDeniedException;
@@ -84,5 +84,13 @@ public class ClientErrorControllerAdvice {
     @ExceptionHandler(BadRequestException.class)
     public ProblemDetail handleBadRequestException(final BadRequestException e) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    /**
+     * 송금 요청이 수락 또는 거절 가능한 상태가 아닌 경우
+     */
+    @ExceptionHandler(InvalidRemittanceRequestStatusException.class)
+    public ProblemDetail handleInvalidRemittanceRequestStatusException(final InvalidRemittanceRequestStatusException e) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
     }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestApplicationService.java
+++ b/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestApplicationService.java
@@ -3,6 +3,7 @@ package com.donggi.sendzy.remittance.application;
 import com.donggi.sendzy.account.application.AccountLockingService;
 import com.donggi.sendzy.account.domain.Account;
 import com.donggi.sendzy.account.domain.AccountService;
+import com.donggi.sendzy.account.domain.LockedAccounts;
 import com.donggi.sendzy.common.exception.BadRequestException;
 import com.donggi.sendzy.member.domain.Member;
 import com.donggi.sendzy.member.domain.MemberService;
@@ -39,12 +40,9 @@ public class RemittanceRequestApplicationService {
         validateSenderAndReceiver(senderId, receiverId);
 
         // 계좌 ID를 오름차순으로 정렬하여 일관된 순서로 Lock 확보
-        final var accounts = accountLockingService.getAccountsWithLockOrdered(senderId, receiverId);
-        final Account firstAccount = accounts.get(0);
-        final Account secondAccount = accounts.get(1);
-
-        final Account senderAccount = senderId.equals(firstAccount.getMemberId()) ? firstAccount : secondAccount;
-        final Account receiverAccount = receiverId.equals(firstAccount.getMemberId()) ? firstAccount : secondAccount;
+        final LockedAccounts lockedAccounts = accountLockingService.getAccountsWithLockOrdered(senderId, receiverId);
+        final Account senderAccount = lockedAccounts.senderAccount();
+        final Account receiverAccount = lockedAccounts.receiverAccount();
 
         final var sender = memberService.findById(senderAccount.getMemberId());
         final var receiver = memberService.findById(receiverAccount.getMemberId());

--- a/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
+++ b/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
@@ -7,6 +7,7 @@ import com.donggi.sendzy.remittance.domain.service.RemittanceRequestService;
 import com.donggi.sendzy.remittance.domain.service.RemittanceStatusHistoryService;
 import com.donggi.sendzy.remittance.exception.InvalidRemittanceRequestStatusException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,9 +20,13 @@ public class RemittanceRequestProcessor {
     private final RemittanceStatusHistoryService remittanceStatusHistoryService;
 
     @Transactional
-    public void handleAcceptance(final long requestId) {
+    public void handleAcceptance(final long requestId, final long receiverId) {
         // 송금 요청 조회 및 상태 확인 (PENDING 여부)
         final var remittanceRequest = remittanceRequestService.getByIdForUpdate(requestId);
+        if (!remittanceRequest.getReceiverId().equals(receiverId)) {
+            throw new AccessDeniedException("요청 수락 권한이 없습니다.");
+        }
+
         if (!remittanceRequest.isPending()) {
             throw new InvalidRemittanceRequestStatusException(remittanceRequest.getStatus());
         }

--- a/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
+++ b/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
@@ -84,8 +84,4 @@ public class RemittanceRequestProcessor {
             )
         );
     }
-
-    public void handleExpiration() {
-        // 요청 만료
-    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
+++ b/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
@@ -2,6 +2,7 @@ package com.donggi.sendzy.remittance.application;
 
 import com.donggi.sendzy.account.application.AccountLockingService;
 import com.donggi.sendzy.account.domain.AccountService;
+import com.donggi.sendzy.account.domain.LockedAccounts;
 import com.donggi.sendzy.remittance.domain.RemittanceRequest;
 import com.donggi.sendzy.remittance.domain.RemittanceRequestStatus;
 import com.donggi.sendzy.remittance.domain.RemittanceStatusHistory;
@@ -29,9 +30,9 @@ public class RemittanceRequestProcessor {
         validateReceiverAuthorityAndStatus(remittanceRequest, receiverId);
 
         // 송금자/수신자 계좌 락 + 조회 (ID 오름차순 → 데드락 방지)
-        final var accounts = accountLockingService.getAccountsWithLockOrdered(remittanceRequest.getSenderId(), remittanceRequest.getReceiverId());
-        final var senderAccount = remittanceRequest.getSenderId().equals(accounts.get(0).getMemberId()) ? accounts.get(0) : accounts.get(1);
-        final var receiverAccount = remittanceRequest.getReceiverId().equals(accounts.get(0).getMemberId()) ? accounts.get(0) : accounts.get(1);
+        final LockedAccounts lockedAccounts = accountLockingService.getAccountsWithLockOrdered(remittanceRequest.getSenderId(), remittanceRequest.getReceiverId());
+        final var senderAccount = lockedAccounts.senderAccount();
+        final var receiverAccount = lockedAccounts.receiverAccount();
 
         // 이체 처리
         accountService.transfer(senderAccount, receiverAccount, remittanceRequest.getAmount());

--- a/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
+++ b/src/main/java/com/donggi/sendzy/remittance/application/RemittanceRequestProcessor.java
@@ -1,0 +1,35 @@
+package com.donggi.sendzy.remittance.application;
+
+import com.donggi.sendzy.remittance.domain.service.RemittanceRequestService;
+import com.donggi.sendzy.remittance.exception.InvalidRemittanceRequestStatusException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class RemittanceRequestProcessor {
+
+    private final RemittanceRequestService remittanceRequestService;
+
+    @Transactional
+    public void handleAcceptance(final long requestId) {
+        final var remittanceRequest = remittanceRequestService.getByIdForUpdate(requestId);
+
+        if (!remittanceRequest.isPending()) {
+            throw new InvalidRemittanceRequestStatusException(remittanceRequest.getStatus());
+        }
+
+        remittanceRequestService.accept(remittanceRequest);
+    }
+
+
+    public void handleRejection() {
+        // 요청 거절
+    }
+
+
+    public void handleExpiration() {
+        // 요청 만료
+    }
+}

--- a/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
+++ b/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
@@ -26,4 +26,15 @@ public class RemittanceRequestRestController {
         final var receiverId = userDetails.getMemberId();
         remittanceRequestProcessor.handleAcceptance(requestId, receiverId);
     }
+
+    /**
+     * 송금 요청 거절
+     * @param requestId 송금 요청 ID
+     * @param userDetails 로그인 정보
+     */
+    @PostMapping("/{requestId}/reject")
+    public void reject(@PathVariable final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
+        final var receiverId = userDetails.getMemberId();
+        remittanceRequestProcessor.handleRejection(requestId, receiverId);
+    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
+++ b/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
@@ -1,0 +1,29 @@
+package com.donggi.sendzy.remittance.controller;
+
+import com.donggi.sendzy.common.security.CustomUserDetails;
+import com.donggi.sendzy.remittance.application.RemittanceRequestProcessor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/remittance")
+public class RemittanceRequestRestController {
+
+    private final RemittanceRequestProcessor remittanceRequestProcessor;
+
+    /**
+     * 송금 요청 수락
+     * @param requestId 송금 요청 ID
+     * @param userDetails 로그인 정보
+     */
+    @PostMapping("/{requestId}/accept")
+    public void accept(@PathVariable final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
+        final var receiverId = userDetails.getMemberId();
+        remittanceRequestProcessor.handleAcceptance(requestId, receiverId);
+    }
+}

--- a/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
+++ b/src/main/java/com/donggi/sendzy/remittance/controller/RemittanceRequestRestController.java
@@ -22,7 +22,7 @@ public class RemittanceRequestRestController {
      * @param userDetails 로그인 정보
      */
     @PostMapping("/{requestId}/accept")
-    public void accept(@PathVariable final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
+    public void accept(@PathVariable("requestId") final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
         final var receiverId = userDetails.getMemberId();
         remittanceRequestProcessor.handleAcceptance(requestId, receiverId);
     }
@@ -33,7 +33,7 @@ public class RemittanceRequestRestController {
      * @param userDetails 로그인 정보
      */
     @PostMapping("/{requestId}/reject")
-    public void reject(@PathVariable final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
+    public void reject(@PathVariable("requestId") final long requestId, @AuthenticationPrincipal final CustomUserDetails userDetails) {
         final var receiverId = userDetails.getMemberId();
         remittanceRequestProcessor.handleRejection(requestId, receiverId);
     }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequest.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequest.java
@@ -33,4 +33,12 @@ public class RemittanceRequest {
         this.amount = amount;
         this.createdAt = LocalDateTime.now();
     }
+
+    public boolean isPending() {
+        return this.status == RemittanceRequestStatus.PENDING;
+    }
+
+    public void accept() {
+        status = this.status.accept();
+    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequest.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequest.java
@@ -41,4 +41,8 @@ public class RemittanceRequest {
     public void accept() {
         status = this.status.accept();
     }
+
+    public void reject() {
+        status = this.status.reject();
+    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequestStatus.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequestStatus.java
@@ -6,13 +6,23 @@ public enum RemittanceRequestStatus {
         public RemittanceRequestStatus accept() {
             return ACCEPTED;
         }
+
+        @Override
+        public RemittanceRequestStatus reject() {
+            return REJECTED;
+        }
     },
     ACCEPTED,
+    REJECTED,
     EXPIRED,
     CANCELLED,
     ;
 
     public RemittanceRequestStatus accept() {
         throw new UnsupportedOperationException("현재 송금 상태에서는 수락할 수 없습니다: " + this);
+    }
+
+    public RemittanceRequestStatus reject() {
+        throw new UnsupportedOperationException("현재 송금 상태에서는 거절할 수 없습니다: " + this);
     }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequestStatus.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/RemittanceRequestStatus.java
@@ -1,8 +1,18 @@
 package com.donggi.sendzy.remittance.domain;
 
 public enum RemittanceRequestStatus {
-    PENDING,
+    PENDING {
+        @Override
+        public RemittanceRequestStatus accept() {
+            return ACCEPTED;
+        }
+    },
     ACCEPTED,
     EXPIRED,
     CANCELLED,
+    ;
+
+    public RemittanceRequestStatus accept() {
+        throw new UnsupportedOperationException("현재 송금 상태에서는 수락할 수 없습니다: " + this);
+    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/repository/RemittanceRequestRepository.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/repository/RemittanceRequestRepository.java
@@ -18,5 +18,12 @@ public interface RemittanceRequestRepository {
      * @param requestId 조회할 송금 요청 ID
      * @return 조회된 송금 요청 정보
      */
-    Optional<RemittanceRequest> findById(long requestId);
+    Optional<RemittanceRequest> findById(final long requestId);
+
+    /**
+     * 송금 요청 ID로 송금 요청을 조회하고, 조회된 송금 요청에 배타적 잠금(Exclusive Lock)을 겁니다.
+     * @param requestId 조회할 송금 요청 ID
+     * @return 조회된 송금 요청 정보(Optional)
+     */
+    Optional<RemittanceRequest> findByIdForUpdate(final long requestId);
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/repository/RemittanceRequestRepository.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/repository/RemittanceRequestRepository.java
@@ -26,4 +26,10 @@ public interface RemittanceRequestRepository {
      * @return 조회된 송금 요청 정보(Optional)
      */
     Optional<RemittanceRequest> findByIdForUpdate(final long requestId);
+
+    /**
+     * 송금 요청 정보를 업데이트합니다.
+     * @param remittanceRequest 업데이트할 송금 요청 정보
+     */
+    void update(final RemittanceRequest remittanceRequest);
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
@@ -22,7 +22,12 @@ public class RemittanceRequestService {
     @Transactional
     public void accept(final RemittanceRequest remittanceRequest) {
         remittanceRequest.accept();
+        remittanceRequestRepository.update(remittanceRequest);
+    }
 
+    @Transactional
+    public void reject(final RemittanceRequest remittanceRequest) {
+        remittanceRequest.reject();
         remittanceRequestRepository.update(remittanceRequest);
     }
 

--- a/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
@@ -24,4 +24,10 @@ public class RemittanceRequestService {
         return remittanceRequestRepository.findById(requestId)
             .orElseThrow(RemittanceRequestNotFoundException::new);
     }
+
+    @Transactional(readOnly = true)
+    public RemittanceRequest getByIdForUpdate(final long requestId) {
+        return remittanceRequestRepository.findByIdForUpdate(requestId)
+            .orElseThrow(RemittanceRequestNotFoundException::new);
+    }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
+++ b/src/main/java/com/donggi/sendzy/remittance/domain/service/RemittanceRequestService.java
@@ -19,6 +19,13 @@ public class RemittanceRequestService {
         return remittanceRequest.getId();
     }
 
+    @Transactional
+    public void accept(final RemittanceRequest remittanceRequest) {
+        remittanceRequest.accept();
+
+        remittanceRequestRepository.update(remittanceRequest);
+    }
+
     @Transactional(readOnly = true)
     public RemittanceRequest getById(final long requestId) {
         return remittanceRequestRepository.findById(requestId)

--- a/src/main/java/com/donggi/sendzy/remittance/exception/InvalidRemittanceRequestStatusException.java
+++ b/src/main/java/com/donggi/sendzy/remittance/exception/InvalidRemittanceRequestStatusException.java
@@ -5,6 +5,6 @@ import com.donggi.sendzy.remittance.domain.RemittanceRequestStatus;
 public class InvalidRemittanceRequestStatusException extends RuntimeException {
 
     public InvalidRemittanceRequestStatusException(final RemittanceRequestStatus status) {
-        super("이미 처리된 송금 요청입니다. 현재 상태는 + '" + status +  "'입니다.");
+        super("이미 처리된 송금 요청입니다. 현재 상태는 '" + status +  "'입니다.");
     }
 }

--- a/src/main/java/com/donggi/sendzy/remittance/exception/InvalidRemittanceRequestStatusException.java
+++ b/src/main/java/com/donggi/sendzy/remittance/exception/InvalidRemittanceRequestStatusException.java
@@ -1,0 +1,10 @@
+package com.donggi.sendzy.remittance.exception;
+
+import com.donggi.sendzy.remittance.domain.RemittanceRequestStatus;
+
+public class InvalidRemittanceRequestStatusException extends RuntimeException {
+
+    public InvalidRemittanceRequestStatusException(final RemittanceRequestStatus status) {
+        super("이미 처리된 송금 요청입니다. 현재 상태는 + '" + status +  "'입니다.");
+    }
+}

--- a/src/main/java/com/donggi/sendzy/remittance/infrastructure/RemittanceRequestMapper.java
+++ b/src/main/java/com/donggi/sendzy/remittance/infrastructure/RemittanceRequestMapper.java
@@ -14,5 +14,7 @@ public interface RemittanceRequestMapper extends RemittanceRequestRepository, Te
 
     Optional<RemittanceRequest> findById(final long requestId);
 
+    Optional<RemittanceRequest> findByIdForUpdate(final long requestId);
+
     void deleteAll();
 }

--- a/src/main/resources/mappers/AccountMapper.xml
+++ b/src/main/resources/mappers/AccountMapper.xml
@@ -12,7 +12,7 @@
         SELECT id, member_id, balance, pending_amount FROM account WHERE member_id = #{memberId}
     </select>
 
-    <select id="findByIdForUpdate" parameterType="long" resultType="com.donggi.sendzy.account.domain.Account">
+    <select id="findByMemberIdForUpdate" parameterType="long" resultType="com.donggi.sendzy.account.domain.Account">
         SELECT id, member_id, balance, pending_amount FROM account WHERE member_id = #{memberId} FOR UPDATE
     </select>
 
@@ -21,11 +21,9 @@
         DELETE FROM account
     </delete>
 
-    <update id="updatePendingAmount">
-        UPDATE account SET pending_amount = #{pendingAmount} WHERE id = #{id}
-    </update>
-
-    <update id="updateBalance">
-        UPDATE account SET balance = #{balance} WHERE id = #{id}
+    <update id="update" parameterType="com.donggi.sendzy.account.domain.Account">
+        UPDATE account
+        SET member_id = #{memberId}, balance = #{balance}, pending_amount = #{pendingAmount}
+        WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mappers/RemittanceRequestMapper.xml
+++ b/src/main/resources/mappers/RemittanceRequestMapper.xml
@@ -15,4 +15,8 @@
     <select id="findById" parameterType="long" resultType="com.donggi.sendzy.remittance.domain.RemittanceRequest">
         SELECT id, sender_id, receiver_id, status, amount, created_at FROM remittance_request WHERE id = #{id}
     </select>
+
+    <select id="findByIdForUpdate" parameterType="long" resultType="com.donggi.sendzy.remittance.domain.RemittanceRequest">
+        SELECT id, sender_id, receiver_id, status, amount, created_at FROM remittance_request WHERE id = #{id} FOR UPDATE
+    </select>
 </mapper>

--- a/src/main/resources/mappers/RemittanceRequestMapper.xml
+++ b/src/main/resources/mappers/RemittanceRequestMapper.xml
@@ -12,6 +12,12 @@
         DELETE FROM remittance_request
     </delete>
 
+    <update id="update" parameterType="com.donggi.sendzy.remittance.domain.RemittanceRequest">
+        UPDATE remittance_request
+        SET sender_id = #{senderId}, receiver_id = #{receiverId}, status = #{status}, amount = #{amount}, created_at = #{createdAt}
+        WHERE id = #{id}
+    </update>
+
     <select id="findById" parameterType="long" resultType="com.donggi.sendzy.remittance.domain.RemittanceRequest">
         SELECT id, sender_id, receiver_id, status, amount, created_at FROM remittance_request WHERE id = #{id}
     </select>

--- a/src/test/java/com/donggi/sendzy/account/domain/AccountRepositoryTest.java
+++ b/src/test/java/com/donggi/sendzy/account/domain/AccountRepositoryTest.java
@@ -46,7 +46,7 @@ public class AccountRepositoryTest {
         final var memberId = TestUtils.DEFAULT_MEMBER_ID;
 
         // when
-        final var actual = accountRepository.findByIdForUpdate(memberId).get();
+        final var actual = accountRepository.findByMemberIdForUpdate(memberId).get();
 
         // then
         assertThat(actual.getMemberId()).isEqualTo(memberId);

--- a/src/test/java/com/donggi/sendzy/account/domain/AccountTest.java
+++ b/src/test/java/com/donggi/sendzy/account/domain/AccountTest.java
@@ -84,7 +84,7 @@ public class AccountTest {
                 final var account = new Account(memberId);
 
                 // when & then
-                assertThatThrownBy(() -> account.withdraw(null))
+                assertThatThrownBy(() -> account.reserveWithdraw(null))
                     .isInstanceOf(ValidException.class)
                     .hasMessage("amount 은/는 null이 될 수 없습니다.");
             }
@@ -97,7 +97,7 @@ public class AccountTest {
                 final var amount = -1L;
 
                 // when & then
-                assertThatThrownBy(() -> account.withdraw(amount))
+                assertThatThrownBy(() -> account.reserveWithdraw(amount))
                     .isInstanceOf(InvalidWithdrawalException.class)
                     .hasMessage("송금액은 0원 이상이어야 합니다. 사용자 요청 금액: -1");
             }
@@ -110,7 +110,7 @@ public class AccountTest {
                 final var amount = 0L;
 
                 // when & then
-                assertThatThrownBy(() -> account.withdraw(amount))
+                assertThatThrownBy(() -> account.reserveWithdraw(amount))
                     .isInstanceOf(InvalidWithdrawalException.class)
                     .hasMessage("송금액은 0원 이상이어야 합니다. 사용자 요청 금액: 0");
             }
@@ -123,7 +123,7 @@ public class AccountTest {
                 final var amount = 100L;
 
                 // when & then
-                assertThatThrownBy(() -> account.withdraw(amount))
+                assertThatThrownBy(() -> account.reserveWithdraw(amount))
                     .isInstanceOf(InvalidWithdrawalException.class)
                     .hasMessage("잔액이 부족합니다.");
             }
@@ -138,7 +138,7 @@ public class AccountTest {
                 account.deposit(depositAmount);
 
                 // when
-                account.withdraw(withdrawAmount);
+                account.reserveWithdraw(withdrawAmount);
 
                 // then
                 assertThat(account.getPendingAmount()).isEqualTo(withdrawAmount);

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
@@ -117,7 +117,7 @@ public class RemittanceRequestAcceptanceTest {
                 final var actual = assertThrows(InvalidRemittanceRequestStatusException.class, () -> remittanceRequestProcessor.handleAcceptance(requestId, receiverId));
 
                 // then
-                assertThat(actual.getMessage()).isEqualTo("이미 처리된 송금 요청입니다. 현재 상태는 + '" + status +  "'입니다.");
+                assertThat(actual.getMessage()).isEqualTo("이미 처리된 송금 요청입니다. 현재 상태는 '" + status +  "'입니다.");
             }
         }
 

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
@@ -149,7 +149,7 @@ public class RemittanceRequestAcceptanceTest {
                 );
 
                 // then
-                assertThat(actual.getMessage()).isEqualTo("요청 수락 권한이 없습니다.");
+                assertThat(actual.getMessage()).isEqualTo("해당 송금 요청의 수신자만 처리할 수 있습니다.");
             }
         }
     }

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.donggi.sendzy.remittance.application;
 
+import com.donggi.sendzy.account.domain.TestAccountRepository;
 import com.donggi.sendzy.member.TestUtils;
 import com.donggi.sendzy.member.application.SignupService;
 import com.donggi.sendzy.member.domain.MemberService;
@@ -11,6 +12,7 @@ import com.donggi.sendzy.remittance.domain.repository.TestRemittanceRequestRepos
 import com.donggi.sendzy.remittance.domain.service.RemittanceRequestService;
 import com.donggi.sendzy.remittance.exception.InvalidRemittanceRequestStatusException;
 import com.donggi.sendzy.remittance.exception.RemittanceRequestNotFoundException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -25,10 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings({"InnerClassMayBeStatic", "NonAsciiCharacters"})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class RemittanceRequestProcessorTest {
+public class RemittanceRequestAcceptanceTest {
 
     @Autowired
-    private RemittanceRequestService remittanceRequestService;
+    private TestMemberRepository memberRepository;
+
+    @Autowired
+    private TestAccountRepository accountRepository;
 
     @Autowired
     private TestRemittanceRequestRepository remittanceRequestRepository;
@@ -37,7 +42,7 @@ public class RemittanceRequestProcessorTest {
     private SignupService signupService;
 
     @Autowired
-    private TestMemberRepository memberRepository;
+    private RemittanceRequestService remittanceRequestService;
 
     @Autowired
     private MemberService memberService;
@@ -50,6 +55,7 @@ public class RemittanceRequestProcessorTest {
     @BeforeEach
     void setUp() {
         remittanceRequestRepository.deleteAll();
+        accountRepository.deleteAll();
         memberRepository.deleteAll();
 
         final var senderEmail = "sender@sendzy.com";
@@ -68,6 +74,13 @@ public class RemittanceRequestProcessorTest {
                 1000L
             )
         );
+    }
+
+    @AfterEach
+    void tearDown() {
+        remittanceRequestRepository.deleteAll();
+        accountRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Nested

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
@@ -135,7 +135,7 @@ public class RemittanceRequestRejectionTest {
                 );
 
                 // then
-                assertThat(actual.getMessage()).isEqualTo("이미 처리된 송금 요청입니다. 현재 상태는 + '" + request.getStatus() +  "'입니다.");
+                assertThat(actual.getMessage()).isEqualTo("이미 처리된 송금 요청입니다. 현재 상태는 '" + request.getStatus() +  "'입니다.");
             }
         }
     }

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
@@ -117,7 +117,7 @@ public class RemittanceRequestRejectionTest {
                 );
 
                 // then
-                assertThat(exception.getMessage()).isEqualTo("송금 요청에 대한 권한이 없습니다.");
+                assertThat(exception.getMessage()).isEqualTo("해당 송금 요청의 수신자만 처리할 수 있습니다.");
             }
         }
 

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceRequestRejectionTest.java
@@ -1,0 +1,142 @@
+package com.donggi.sendzy.remittance.application;
+
+import com.donggi.sendzy.account.domain.TestAccountRepository;
+import com.donggi.sendzy.member.TestUtils;
+import com.donggi.sendzy.member.application.SignupService;
+import com.donggi.sendzy.member.domain.MemberService;
+import com.donggi.sendzy.member.domain.TestMemberRepository;
+import com.donggi.sendzy.member.dto.SignupRequest;
+import com.donggi.sendzy.remittance.domain.RemittanceRequest;
+import com.donggi.sendzy.remittance.domain.RemittanceRequestStatus;
+import com.donggi.sendzy.remittance.domain.repository.TestRemittanceRequestRepository;
+import com.donggi.sendzy.remittance.domain.service.RemittanceRequestService;
+import com.donggi.sendzy.remittance.exception.InvalidRemittanceRequestStatusException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings({"InnerClassMayBeStatic", "NonAsciiCharacters"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RemittanceRequestRejectionTest {
+
+    @Autowired
+    private TestMemberRepository memberRepository;
+
+    @Autowired
+    private TestAccountRepository accountRepository;
+
+    @Autowired
+    private TestRemittanceRequestRepository remittanceRequestRepository;
+
+    @Autowired
+    private SignupService signupService;
+
+    @Autowired
+    private RemittanceRequestService remittanceRequestService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private RemittanceRequestProcessor remittanceRequestProcessor;
+
+    private Long requestId;
+    private Long receiverId;
+
+    @BeforeEach
+    void setUp() {
+        remittanceRequestRepository.deleteAll();
+        accountRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        final var senderEmail = "sender@sendzy.com";
+        final var receiverEmail = "receiver@sendzy.com";
+        signupService.signup(new SignupRequest(senderEmail, TestUtils.DEFAULT_RAW_PASSWORD));
+        signupService.signup(new SignupRequest(receiverEmail, TestUtils.DEFAULT_RAW_PASSWORD));
+
+        final var sender = memberService.findByEmail(senderEmail).get();
+        final var receiver = memberService.findByEmail(receiverEmail).get();
+
+        receiverId = receiver.getId();
+
+        requestId = remittanceRequestService.recordRequestAndGetId(
+            new RemittanceRequest(
+                sender.getId(),
+                receiverId,
+                RemittanceRequestStatus.PENDING,
+                1000L
+            )
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        remittanceRequestRepository.deleteAll();
+        accountRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Nested
+    class 송금_요청_거절_시 {
+
+        @Nested
+        class 수신자가_송금_요청을_거절하면 {
+            @Test
+            void 상태가_REJECTED로_변경된다() {
+                // when
+                remittanceRequestProcessor.handleRejection(requestId, receiverId);
+
+                // then
+                final var request = remittanceRequestService.getById(requestId);
+                assertThat(request.getStatus()).isEqualTo(RemittanceRequestStatus.REJECTED);
+            }
+        }
+
+        @Nested
+        class 수신자가_아닌_회원이_거절하면 {
+            @Test
+            void AccessDeniedException_예외가_발생한다() {
+                // given: 수신자가 아닌 사용자 추가
+                final var otherEmail = "intruder@sendzy.com";
+                signupService.signup(new SignupRequest(otherEmail, TestUtils.DEFAULT_RAW_PASSWORD));
+                final var otherMember = memberService.findByEmail(otherEmail).get();
+
+                // when
+                final var exception = assertThrows(AccessDeniedException.class, () ->
+                    remittanceRequestProcessor.handleRejection(requestId, otherMember.getId())
+                );
+
+                // then
+                assertThat(exception.getMessage()).isEqualTo("송금 요청에 대한 권한이 없습니다.");
+            }
+        }
+
+        @Nested
+        class 이미_처리된_요청은 {
+            @Test
+            void InvalidRemittanceRequestStatusException_예외가_반환된다() {
+                // given
+                final var request = remittanceRequestService.getById(requestId);
+                remittanceRequestService.accept(request);
+
+                // when
+                final var actual = assertThrows(InvalidRemittanceRequestStatusException.class, () ->
+                    remittanceRequestProcessor.handleRejection(requestId, receiverId)
+                );
+
+                // then
+                assertThat(actual.getMessage()).isEqualTo("이미 처리된 송금 요청입니다. 현재 상태는 + '" + request.getStatus() +  "'입니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/donggi/sendzy/remittance/application/RemittanceResponseServiceTest.java
+++ b/src/test/java/com/donggi/sendzy/remittance/application/RemittanceResponseServiceTest.java
@@ -1,0 +1,87 @@
+package com.donggi.sendzy.remittance.application;
+
+import com.donggi.sendzy.account.domain.AccountService;
+import com.donggi.sendzy.member.TestUtils;
+import com.donggi.sendzy.member.application.SignupService;
+import com.donggi.sendzy.member.domain.MemberService;
+import com.donggi.sendzy.member.domain.TestMemberRepository;
+import com.donggi.sendzy.member.dto.SignupRequest;
+import com.donggi.sendzy.remittance.domain.RemittanceRequest;
+import com.donggi.sendzy.remittance.domain.RemittanceRequestStatus;
+import com.donggi.sendzy.remittance.domain.repository.TestRemittanceRequestRepository;
+import com.donggi.sendzy.remittance.domain.service.RemittanceRequestService;
+import com.donggi.sendzy.remittance.exception.RemittanceRequestNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings({"InnerClassMayBeStatic", "NonAsciiCharacters"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RemittanceResponseServiceTest {
+
+    // 인증된 사용자의 송금 건의 상태가 PENDING이면서 만료되지 않은 경우, 송금 요청이 수락/거절 처리되고 송금 요청 상태 변경 이력이 기록되어야 함
+    // 송금 건이 수락되면 송금자의 잔액이 차감되어야 하고, 거절되면 송금자의 잔액이 복구되어야 함
+    @Autowired
+    private RemittanceRequestService remittanceRequestService;
+
+    @Autowired
+    private TestRemittanceRequestRepository remittanceRequestRepository;
+
+    @Autowired
+    private SignupService signupService;
+
+    @Autowired
+    private TestMemberRepository memberRepository;
+
+    private void doSomething(final long requestId, final RemittanceRequestStatus status) {
+        remittanceRequestService.getByIdForUpdate(requestId);
+    }
+
+    private Long requestId;
+
+    @BeforeEach
+    void setUp() {
+        remittanceRequestRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        final var senderEmail = "sender@sendzy.com";
+        final var receiverEmail = "receiver@sendzy.com";
+        signupService.signup(new SignupRequest(senderEmail, TestUtils.DEFAULT_RAW_PASSWORD));
+        signupService.signup(new SignupRequest(receiverEmail, TestUtils.DEFAULT_RAW_PASSWORD));
+
+        requestId = remittanceRequestService.recordRequestAndGetId(
+            new RemittanceRequest(
+                1L,
+                2L,
+                RemittanceRequestStatus.PENDING,
+                1000L
+            )
+        );
+    }
+
+    @Nested
+    class 송금_요청_수락_시 {
+        @Nested
+        class 송금_요청이_존재하지_않을_경우 {
+            @Test
+            void RemittanceRequestNotFoundException_예외가_발생한다() {
+                // given
+                final long requestId = 999999999999L;
+
+                // when
+                final var exception = assertThrows(RemittanceRequestNotFoundException.class, () -> doSomething(requestId, RemittanceRequestStatus.ACCEPTED));
+
+                // then
+                assertThat(exception.getMessage()).isEqualTo("송금 요청 정보를 찾을 수 없습니다.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
@f-lab-maverick 
안녕하세요! 송금 요청 수락/거절 기능 개발 완료되어 리뷰 요청 드립니다.

--- 

**주요 변경 사항**
- 수신자가 송금 요청을 수락하거나 거절할 수 있는 기능 추가
- 송금 요청 처리 시 다음과 같은 조건 및 흐름을 따릅니다.
  - **수신자 본인**만 처리 가능 (memberId 기반 권한 검증)
  - 요청 상태가 **PENDING**인 경우에만 처리 가능
  - 수락 시 송금자/수신자의 계좌를 오름차순으로 조회하여 락을 획득하고, 출금 및 입금 처리
  - 거절 시 송금자의 대기 출금 금액을 롤백 처리
  - 각 처리 이후 송금 상태 히스토리를 기록

**상세 구현 내용**
- **RemittanceRequestProcessor**  
  - `handleAcceptance(requestId, receiverId)` : 수락 처리
  - `handleRejection(requestId, receiverId)` : 거절 처리  
 → 두 메서드 모두 수신자 권한 및 요청 상태 검증을 포함하며, 처리 완료 후 상태 히스토리를 저장합니다.
- **RemittanceRequestStatus** 
  - enum 클래스에 상태별 수락/거절 가능 여부를 정의하여, 각 요청이 처리 가능한 상태인지 비즈니스 규칙을 적용했습니다. 
  - 도메인 객체는 단순히 **변경 의도**만 표현하며, 실제 유효성 검증 책임은 상태가 직접 갖도록 설계했습니다.